### PR TITLE
chore: create upload directory when server starts

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,14 +2,20 @@ import './lockdown.js';
 import express from 'express';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { fs } from 'zx';
 import router from './router.js';
 import { requestLogger } from './middleware/requestLogger.js';
 
 const PORT = 3000;
+const UPLOAD_DIR = 'uploads';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const app = express();
+
+if (!fs.existsSync(UPLOAD_DIR)) {
+  fs.mkdirSync(UPLOAD_DIR);
+}
 
 // Serve static files
 app.use(express.static(path.join(__dirname, 'public')));

--- a/services/fileProcessor.js
+++ b/services/fileProcessor.js
@@ -1,4 +1,3 @@
-import { fs } from 'zx';
 import path from 'path';
 import { processSlogs } from './slogProcessor.js';
 import { convertToSVG } from './pumlToSvgConverter.js';
@@ -15,10 +14,6 @@ export const processAndConvert = async ({ inputFile, res }) => {
   let outputFile, svgFilePath, svgDirPath;
 
   try {
-    if (!fs.existsSync(uploadDir)) {
-      fs.mkdirSync(uploadDir);
-    }
-
     outputFile = `${uploadDir}/processed-${uniqueSuffix}.puml`;
     console.log('Processing Slogs....');
     await processSlogs({ inputFile, outputFile });


### PR DESCRIPTION
While testing the Causeway deployment on Kubernetes, I discovered that although the server starts successfully, file uploads consistently fail due to the upload directory not being created on time. To resolve this issue, I have adjusted the server's startup process to ensure the directory is created beforehand.

Here are the relevant Kubernetes logs:
```bash
kubectl logs causeway-prod-5d5694c76b-5ggb8
plantuml.jar not found. Downloading...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 9862k  100 9862k    0     0   935k      0  0:00:10  0:00:10 --:--:-- 1279k
Downloaded plantuml.jar successfully.
Running in production mode...
yarn run v1.22.22
$ node index.js
Server listening on 3000
Multiple 'POST /upload' requests resulted in 'ENOENT: no such file or directory' errors, indicating the absence of the required 'uploads' directory.
```

These logs were generated while addressing file upload failures, and the adjustments to directory creation should prevent further errors of this nature.
